### PR TITLE
Little changes

### DIFF
--- a/pywerview/worker/hunting.py
+++ b/pywerview/worker/hunting.py
@@ -39,9 +39,14 @@ class HunterWorker(Process):
 
     def run(self):
         while True:
-            target_computer = self._pipe.recv()
-            result = self._hunt(target_computer)
-            self._pipe.send(result)
+            try:
+                target_computer = self._pipe.recv()
+                result = self._hunt(target_computer)
+                self._pipe.send(result)
+            except:
+                # print stacktrace in debug mode
+                self._pipe.send('')
+                pass
 
 class UserHunterWorker(HunterWorker):
     def __init__(self, pipe, domain, user, password, lmhash, nthash, foreign_users,
@@ -84,7 +89,6 @@ class UserHunterWorker(HunterWorker):
                 # We see if it's in our target user group
                 for target_user in self._target_users:
                     if target_user.membername.lower() in username.lower():
-
                         # If we fall in this branch, we're looking for foreign users
                         # and found a user in the same domain
                         if self._domain_short_name and self._domain_short_name.lower() == userdomain.lower():


### PR DESCRIPTION
Hi, 

I was using your tool on a big AD (around 20 000 hosts) and I had to debug some functions because I had stacktraces like these ones: 

- When data is empty, data.index fails
```
Process UserHunterWorker-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/home/test/pywerview/pywerview/worker/hunting.py", line 43, in run
    result = self._hunt(target_computer)
  File "/home/test/pywerview/pywerview/worker/hunting.py", line 63, in _hunt
    self._lmhash, self._nthash) as net_requester:
  File "/home/test/pywerview/pywerview/requester.py", line 273, in __enter__
    LDAPRequester.__enter__(self)
  File "/home/test/pywerview/pywerview/requester.py", line 144, in __enter__
    self._create_ldap_connection()
  File "/home/test/pywerview/pywerview/requester.py", line 62, in _create_ldap_connection
    queried_domain = self._get_netfqdn()
  File "/home/test/pywerview/pywerview/requester.py", line 50, in _get_netfqdn
    smb.login('', '')
  File "/usr/local/lib/python2.7/dist-packages/impacket/smbconnection.py", line 258, in login
    return self._SMBConnection.login(user, password, domain, lmhash, nthash, ntlmFallback)
  File "/usr/local/lib/python2.7/dist-packages/impacket/smb.py", line 3376, in login
    self.login_extended(user, password, domain, lmhash, nthash, use_ntlmv2 = True)
  File "/usr/local/lib/python2.7/dist-packages/impacket/smb.py", line 3252, in login_extended
    sessionData.fromString(sessionResponse['Data'])
  File "/usr/local/lib/python2.7/dist-packages/impacket/structure.py", line 140, in fromString
    size = self.calcUnpackSize(field[1], data, field[0])
  File "/usr/local/lib/python2.7/dist-packages/impacket/structure.py", line 462, in calcUnpackSize
    return self.calcUnpackSize(two[0], data)
  File "/usr/local/lib/python2.7/dist-packages/impacket/structure.py", line 494, in calcUnpackSize
    return data.index('\x00')+1
ValueError: substring not found
```

- Another one: 
```
Process UserHunterWorker-7:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/home/joe/pywerview/pywerview/worker/hunting.py", line 43, in run
    result = self._hunt(target_computer)
  File "/home/joe/pywerview/pywerview/worker/hunting.py", line 65, in _hunt
    distant_sessions += net_requester.get_netsession()
TypeError: 'NoneType' object is not iterable
```
So to correct it, at first I tried to debug it but I finally add this [check](https://github.com/the-useless-one/pywerview/commit/ed41eb0a9b071e2093d2a9e5c4d63ee1a5b0d2b5#diff-2f91bdb7ff70d36ae23cc098fc669eb2R48) and return empty value if it fails. I had no more stacktrace. 

Another problem I had, it's on big AD, the request (invoke-userhunter) could take a while, so it's difficult to know if the tool is working or not so I added some prints and a progress bar to know the elapsed time. If you want to remove it, no problem, but please add some verbose options. 

I wanted to improve the elapsed time, that's why I added a timeout [here](https://github.com/the-useless-one/pywerview/compare/master...AlessandroZ:master#diff-f0cf747951625420f322f8d414456b8eR167) but I doesn't change a lot. 

Hope it will help. Have a nice day and thanks for your work ! 