### PR TITLE
datetime function exception fix

### DIFF
--- a/pywerview/objects/adobjects.py
+++ b/pywerview/objects/adobjects.py
@@ -53,8 +53,11 @@ class ADObject:
                 for val in attr['vals']:
                     value.append(str(datetime.strptime(str(val), '%Y%m%d%H%M%S.0Z')))
             elif t in ('pwdlastset', 'badpasswordtime', 'lastlogon', 'lastlogoff'):
-                timestamp = (int(str(attr['vals'][0])) - 116444736000000000)/10000000
-                value = datetime.fromtimestamp(timestamp)
+                try:
+                    timestamp = (int(str(attr['vals'][0])) - 116444736000000000)/10000000
+                    value = datetime.fromtimestamp(timestamp)
+                except (ValueError):
+                    value = datetime.min 
             elif t == 'isgroup':
                 value = attr['vals'][0]
             elif t == 'objectclass':

--- a/pywerview/objects/adobjects.py
+++ b/pywerview/objects/adobjects.py
@@ -51,7 +51,10 @@ class ADObject:
             elif t in ('dscorepropagationdata', 'whenchanged', 'whencreated'):
                 value = list()
                 for val in attr['vals']:
-                    value.append(str(datetime.strptime(str(val), '%Y%m%d%H%M%S.0Z')))
+                    try:
+                        value.append(str(datetime.strptime(str(val), '%Y%m%d%H%M%S.0Z')))
+                    except (ValueError):
+                        pass
             elif t in ('pwdlastset', 'badpasswordtime', 'lastlogon', 'lastlogoff'):
                 try:
                     timestamp = (int(str(attr['vals'][0])) - 116444736000000000)/10000000


### PR DESCRIPTION
In some environments I have encountered zero value in Date fields.
The datetime conversion function was throwing an exception in these cases:

python pywerview.py get-netgroupmember -t 1.2.3.4 -u user -p pass --groupname 'Group Name'

Traceback (most recent call last):
  File "pywerview.py", line 24, in <module>
    main()
  File "pywerview/pywerview/cli/main.py", line 456, in main
    results = args.func(**parsed_args)
  File "pywerview/pywerview/cli/helpers.py", line 134, in get_netgroupmember
    full_data=full_data, custom_filter=custom_filter)
  File "pywerview/pywerview/requester.py", line 140, in wrapper
    return f(*args, **kwargs)
  File "pywerview/pywerview/functions/net.py", line 405, in get_netgroupmember
    members = _get_members(groupname, sid)
  File "pywerview/pywerview/functions/net.py", line 363, in _get_members
    members += self.get_netuser(custom_filter=dn_filter, queried_domain=queried_domain)
  File "pywerview/pywerview/requester.py", line 140, in wrapper
    return f(*args, **kwargs)
  File "pywerview/pywerview/functions/net.py", line 71, in get_netuser
    return self._ldap_search(user_search_filter, adobj.User)
  File "pywerview/pywerview/requester.py", line 121, in _ldap_search
    results.append(class_result(result['attributes']))
  File "pywerview/pywerview/objects/adobjects.py", line 112, in __init__
    ADObject.__init__(self, attributes)
  File "pywerview/pywerview/objects/adobjects.py", line 27, in __init__
    self.add_attributes(attributes)
  File "pywerview/pywerview/objects/adobjects.py", line 57, in add_attributes
    value = datetime.fromtimestamp(timestamp)
ValueError: timestamp out of range for platform time_t
