### PR TITLE
get-netuser, get-netcomputer return custom --attributes

### DIFF
--- a/pywerview/cli/helpers.py
+++ b/pywerview/cli/helpers.py
@@ -37,13 +37,15 @@ def get_adobject(domain_controller, domain, user, password=str(),
 def get_netuser(domain_controller, domain, user, password=str(), lmhash=str(),
                 nthash=str(), queried_username=str(), queried_domain=str(), ads_path=str(),
                 admin_count=False, spn=False, unconstrained=False, allow_delegation=False,
-                preauth_notreq=False, custom_filter=str()):
+                preauth_notreq=False, custom_filter=str(),
+                attributes=[]):
 	requester = NetRequester(domain_controller, domain, user, password,
                                  lmhash, nthash)
 	return requester.get_netuser(queried_username=queried_username,
                                     queried_domain=queried_domain, ads_path=ads_path, admin_count=admin_count,
                                     spn=spn, unconstrained=unconstrained, allow_delegation=allow_delegation,
-                                    preauth_notreq=preauth_notreq, custom_filter=custom_filter)
+                                    preauth_notreq=preauth_notreq, custom_filter=custom_filter,
+                                    attributes=attributes)
 
 def get_netgroup(domain_controller, domain, user, password=str(),
                 lmhash=str(), nthash=str(), queried_groupname='*', queried_sid=str(),
@@ -60,14 +62,14 @@ def get_netcomputer(domain_controller, domain, user, password=str(),
                     lmhash=str(), nthash=str(), queried_computername='*', queried_spn=str(),
                     queried_os=str(), queried_sp=str(), queried_domain=str(), ads_path=str(),
                     printers=False, unconstrained=False, ping=False, full_data=False,
-                    custom_filter=str()):
+                    custom_filter=str(), attributes=[]):
 	requester = NetRequester(domain_controller, domain, user, password,
                                  lmhash, nthash)
 	return requester.get_netcomputer(queried_computername=queried_computername,
                                         queried_spn=queried_spn, queried_os=queried_os, queried_sp=queried_sp,
                                         queried_domain=queried_domain, ads_path=ads_path, printers=printers,
                                         unconstrained=unconstrained, ping=ping, full_data=full_data,
-                                        custom_filter=custom_filter)
+                                        custom_filter=custom_filter, attributes=attributes)
 
 def get_netdomaincontroller(domain_controller, domain, user, password=str(),
                                  lmhash=str(), nthash=str(), queried_domain=str()):

--- a/pywerview/cli/main.py
+++ b/pywerview/cli/main.py
@@ -112,6 +112,8 @@ def main():
             help='Query only users with not-null Service Principal Names')
     get_netuser_parser.add_argument('--custom-filter', dest='custom_filter',
             default=str(), help='Custom filter')
+    get_netuser_parser.add_argument('--attributes', nargs='+', dest='attributes',
+            default=[], help='Object attributes to return')
     get_netuser_parser.set_defaults(func=get_netuser)
 
     # Parser for the get-netgroup command
@@ -156,6 +158,8 @@ def main():
             help='Ping computers (will only return up computers)')
     get_netcomputer_parser.add_argument('--full-data', action='store_true',
             help='If set, returns full information on the groups, otherwise, just the dnsHostName')
+    get_netcomputer_parser.add_argument('--attributes', nargs='+', dest='attributes',
+            default=[], help='Object attributes to return')
     get_netcomputer_parser.set_defaults(func=get_netcomputer)
 
     # Parser for the get-netdomaincontroller command

--- a/pywerview/functions/net.py
+++ b/pywerview/functions/net.py
@@ -50,7 +50,7 @@ class NetRequester(LDAPRPCRequester):
                     ads_path=str(), admin_count=False, spn=False,
                     unconstrained=False, allow_delegation=False,
                     preauth_notreq=False,
-                    custom_filter=str()):
+                    custom_filter=str(), attributes=[]):
 
         if unconstrained:
             custom_filter += '(userAccountControl:1.2.840.113556.1.4.803:=524288)'
@@ -71,7 +71,7 @@ class NetRequester(LDAPRPCRequester):
 
         user_search_filter = '(&{})'.format(user_search_filter)
 
-        return self._ldap_search(user_search_filter, adobj.User)
+        return self._ldap_search(user_search_filter, adobj.User, attributes=attributes)
 
     @LDAPRPCRequester._ldap_connection_init
     def get_netgroup(self, queried_groupname='*', queried_sid=str(),
@@ -143,7 +143,7 @@ class NetRequester(LDAPRPCRequester):
     def get_netcomputer(self, queried_computername='*', queried_spn=str(),
                         queried_os=str(), queried_sp=str(), queried_domain=str(),
                         ads_path=str(), printers=False, unconstrained=False,
-                        ping=False, full_data=False, custom_filter=str()):
+                        ping=False, full_data=False, custom_filter=str(), attributes=[]):
 
         if unconstrained:
             custom_filter += '(userAccountControl:1.2.840.113556.1.4.803:=524288)'
@@ -161,7 +161,8 @@ class NetRequester(LDAPRPCRequester):
         if full_data:
             attributes=list()
         else:
-            attributes=['dnsHostName']
+            if not attributes:
+                attributes=['dnsHostName']
 
         computer_search_filter = '(&{})'.format(computer_search_filter)
 

--- a/pywerview/objects/adobjects.py
+++ b/pywerview/objects/adobjects.py
@@ -139,7 +139,9 @@ class ADObject:
 class User(ADObject):
     def __init__(self, attributes):
         ADObject.__init__(self, attributes)
-        for attr in ('homedirectory', 'scriptpath', 'profilepath'):
+        for attr in filter(lambda _: _ in attributes, ('homedirectory',
+                                                       'scriptpath',
+                                                       'profilepath')):
             if not hasattr(self, attr):
                 setattr(self, attr, str())
 


### PR DESCRIPTION
get-netuser, get-netcomputer can now return specific attributes from the command line.

Ex: ./pywerview.py get-netuser -t 10.13.37.1 -u user -p pw -w corp --attributes samaccountname
Ex: ./pywerview.py get-netcomputer -t 10.13.37.1 -u user -p pw -w corp --attributes dnshostname operatingsystem serviceprincipalname

Possibly good idea to move --attributes argument parsing to ad_parser, but i don't see how we can cleanly implement the receiving of arguments in pywerview/cli/helpers.py get_* functions without majorly refactoring either the function prototypes, or the calling function in pywerview/cli/main.py (other than hacking in *ignoreargs, **ignorekwargs).