### PR TITLE
change close() to unbind()

### DIFF
--- a/pywerview/requester.py
+++ b/pywerview/requester.py
@@ -160,7 +160,7 @@ class LDAPRequester():
                (ads_path != instance._ads_path) or \
                (ads_prefix != instance._ads_prefix):
                 if instance._ldap_connection:
-                    instance._ldap_connection.close()
+                    instance._ldap_connection.unbind()
                 instance._create_ldap_connection(queried_domain=queried_domain,
                                                  ads_path=ads_path, ads_prefix=ads_prefix)
             return f(*args, **kwargs)
@@ -172,7 +172,7 @@ class LDAPRequester():
 
     def __exit__(self, type, value, traceback):
         try:
-            self._ldap_connection.close()
+            self._ldap_connection.unbind()
         except AttributeError:
             pass
         self._ldap_connection = None

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except(IOError, ImportError):
     long_description = open('README.md').read()
 
 setup(name='pywerview',
-    version='0.3.0',
+    version='0.3.1',
     description='A Python port of PowerSploit\'s PowerView',
     long_description=long_description,
     dependency_links = ['https://github.com/SecureAuthCorp/impacket/tarball/master#egg=impacket-0.9.22'],


### PR DESCRIPTION
Oups...

Should fix `get-netgroupmember` when used without `--groupname` (example)

:sunflower: 