### PR TITLE
setup.cfg: fix setuptools deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fixes warning:
`
* Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
`

Signed-off-by: Sam James <sam@gentoo.org>