### PR TITLE
[get-netcomputer] Add flag to query only computers for which the user can read LAPS passwords

### DIFF
--- a/pywerview/cli/helpers.py
+++ b/pywerview/cli/helpers.py
@@ -89,15 +89,15 @@ def get_netcomputer(domain_controller, domain, user, password=str(),
                     lmhash=str(), nthash=str(), do_kerberos=False, do_tls=False,
                     queried_computername='*', queried_spn=str(), queried_os=str(),
                     queried_sp=str(), queried_domain=str(), ads_path=str(),
-                    printers=False, unconstrained=False, ping=False, full_data=False,
-                    custom_filter=str(), attributes=[]):
+                    printers=False, unconstrained=False, laps_passwords=False,
+                    ping=False, full_data=False, custom_filter=str(), attributes=[]):
     requester = NetRequester(domain_controller, domain, user, password,
                                  lmhash, nthash, do_kerberos, do_tls)
     return requester.get_netcomputer(queried_computername=queried_computername,
                                         queried_spn=queried_spn, queried_os=queried_os, queried_sp=queried_sp,
                                         queried_domain=queried_domain, ads_path=ads_path, printers=printers,
-                                        unconstrained=unconstrained, ping=ping, full_data=full_data,
-                                        custom_filter=custom_filter, attributes=attributes)
+                                        unconstrained=unconstrained, laps_passwords=laps_passwords, ping=ping,
+                                        full_data=full_data, custom_filter=custom_filter, attributes=attributes)
 
 def get_netdomaincontroller(domain_controller, domain, user, password=str(),
                                  lmhash=str(), nthash=str(), do_kerberos=False,

--- a/pywerview/cli/main.py
+++ b/pywerview/cli/main.py
@@ -230,6 +230,8 @@ def main():
             help='Query only printers')
     get_netcomputer_parser.add_argument('--unconstrained', action='store_true',
             help='Query only computers with unconstrained delegation')
+    get_netcomputer_parser.add_argument('--laps-passwords', action='store_true', dest='laps_passwords',
+            help='Query only computers for which the user can read LAPS passwords')
     get_netcomputer_parser.add_argument('--ping', action='store_true',
             help='Ping computers (will only return up computers)')
     get_netcomputer_parser.add_argument('--full-data', action='store_true',

--- a/pywerview/functions/net.py
+++ b/pywerview/functions/net.py
@@ -313,7 +313,7 @@ class NetRequester(LDAPRPCRequester):
     @LDAPRPCRequester._ldap_connection_init
     def get_netcomputer(self, queried_computername='*', queried_spn=str(),
                         queried_os=str(), queried_sp=str(), queried_domain=str(),
-                        ads_path=str(), printers=False, unconstrained=False,
+                        ads_path=str(), printers=False, unconstrained=False, laps_passwords=False,
                         ping=False, full_data=False, custom_filter=str(), attributes=[]):
 
         if unconstrained:
@@ -321,6 +321,9 @@ class NetRequester(LDAPRPCRequester):
 
         if printers:
             custom_filter += '(objectCategory=printQueue)'
+
+        if laps_passwords:
+            custom_filter += '(ms-mcs-AdmPwd=*)'
 
         computer_search_filter = '(samAccountType=805306369){}'.format(custom_filter)
         for (attr_desc, attr_value) in (('servicePrincipalName', queried_spn),
@@ -334,6 +337,8 @@ class NetRequester(LDAPRPCRequester):
         else:
             if not attributes:
                 attributes=['dnsHostName']
+            if laps_passwords:
+                attributes.append('ms-mcs-AdmPwd')
 
         computer_search_filter = '(&{})'.format(computer_search_filter)
 


### PR DESCRIPTION
Salut Yannick,

This PR adds the `--laps-passwords` flag to the `get-netcomputer` command, to return only the machines for which the user can read LAPS passwords.

Example use:
```
$ pywerview get-netcomputer -w DOMAIN.LOCAL -u privileged-user -p 'P@ssw0rd' -t 10.0.0.1 --laps-passwords
dnshostname:   SERVER.DOMAIN.LOCAL
ms-mcs-admpwd: )13vN/Y3o0nkI1qw[B72

dnshostname:   WORKSTATION.DOMAIN.LOCAL
ms-mcs-admpwd: DO4%}Vp;QC%.00W;(yR-
```

Cheers!