### PR TITLE
Use beautifulsoup4 instead of bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 impacket>=0.9.22
-bs4
+beautifulsoup4
 lxml
 pyasn1
 ldap3>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='pywerview',
     ]),
     install_requires=[
         'impacket>=0.9.22',
-        'bs4',
+        'beautifulsoup4',
         'lxml',
         'pyasn1',
         'ldap3>=2.8.1',


### PR DESCRIPTION
`bs4` is dummy package for `beautifulsoup4`. Distributions usually don't ship `bs4` but `beautifulsoup4` and this requires them to patch as often the requirements are collected from the setup.py files.