### PR TITLE
Fall back to pycryptodome if pycryptodomex is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Also, blah blah blah, don't use it for evil purposes.
 * impacket >= 0.9.22
 * ldap3 >= 2.8.1
 * gssapi (Which requires `libkrb5-dev`)
+* pycryptodomex (or pycryptodome)
 
 ## FUNCTIONALITIES
 

--- a/README.md
+++ b/README.md
@@ -294,5 +294,5 @@ Public License for more details.
 
 You should have received a copy of the GNU General Public License along
 with this program. If not, see
-[http://www.gnu.org/licenses/](http://www.gnu.org/licenses/).
+[https://www.gnu.org/licenses/](https://www.gnu.org/licenses/).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fork me on [GitHub](https://github.com/the-useless-one/pywerview).
 [![License](https://img.shields.io/github/license/the-useless-one/pywerview)](https://github.com/the-useless-one/pywerview/blob/master/LICENSE)
 ![Python versions](https://img.shields.io/pypi/pyversions/pywerview)
 [![GitHub release](https://img.shields.io/github/v/release/the-useless-one/pywerview)](https://github.com/the-useless-one/pywerview/releases/latest)
-[![PyPI version](https://img.shields.io/pypi/v/pywerview)](https://pypi.python.org/pypi/pywerview)
+[![PyPI version](https://img.shields.io/pypi/v/pywerview)](https://pypi.org/project/pywerview/)
 
 ## HISTORY
 

--- a/pywerview/formatters.py
+++ b/pywerview/formatters.py
@@ -17,7 +17,12 @@
 
 import logging
 import binascii
-from Cryptodome.Hash import MD4
+
+try:
+    from Cryptodome.Hash import MD4
+except ImportError:
+    from Crypto.Hash import MD4
+
 from impacket.examples.ntlmrelayx.attacks.ldapattack import MSDS_MANAGEDPASSWORD_BLOB
 from impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml
 pyasn1
 ldap3>=2.8.1
 gssapi
+pycryptodome

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(name='pywerview',
         'lxml',
         'pyasn1',
         'ldap3>=2.8.1',
-        'gssapi'
+        'gssapi',
+        'pycryptodome',
     ],
     entry_points = {
         'console_scripts': ['pywerview=pywerview.cli.main:main'],


### PR DESCRIPTION
pycryptodomex is a compatibility wrapper for pycryptodome;
the functionality and codebase is the same. Fall back to pycryptodome
if pycryptodomex is not installed.

Signed-off-by: Sam James <sam@gentoo.org>