### PR TITLE
Added a Dockerfile for easy build from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM kalilinux/kali-rolling:latest
+
+RUN apt update && apt install -y git python3 python3-pip libkrb5-dev && pip3 install impacket bs4 gssapi dsinternals && git clone https://github.com/the-useless-one/pywerview.git && cd pywerview && pip3 install -r requirements.txt && python3 setup.py install
+
+ENTRYPOINT ["/usr/local/bin/pywerview"]


### PR DESCRIPTION
I had some trial and error when building from source so I created this Dockerfile to make it easy. All it takes to build the Docker image is `docker build -t pywerview .`

To run it: `docker run --rm -it -v /data:$(pwd) pywerview`. Any output saved to /data will land in the current working directory.

Additionally, it would greatly simplify instructions to build from source if you updated the wiki with the `RUN` line, not including the word RUN.