### PR TITLE
Fixed trailing \x00 while retrieving local disks

### DIFF
--- a/pywerview/functions/net.py
+++ b/pywerview/functions/net.py
@@ -743,7 +743,7 @@ class NetRequester(LDAPRPCRequester):
         results = list()
         for disk in resp['DiskInfoStruct']['Buffer']:
             if disk['Disk'] != '\x00':
-                results.append(rpcobj.Disk(disk))
+                results.append(rpcobj.Disk(disk.rstrip("\x00")))
 
         return results
 

--- a/pywerview/functions/net.py
+++ b/pywerview/functions/net.py
@@ -743,7 +743,7 @@ class NetRequester(LDAPRPCRequester):
         results = list()
         for disk in resp['DiskInfoStruct']['Buffer']:
             if disk['Disk'] != '\x00':
-                results.append(rpcobj.Disk(disk.rstrip("\x00")))
+                results.append(rpcobj.Disk(disk))
 
         return results
 

--- a/pywerview/objects/rpcobjects.py
+++ b/pywerview/objects/rpcobjects.py
@@ -18,10 +18,9 @@
 import logging
 import inspect
 
-
 class RPCObject:
     def __init__(self, obj):
-        logger = logging.getLogger("pywerview_main_logger.RPCObject")
+        logger = logging.getLogger('pywerview_main_logger.RPCObject')
         logger.ULTRA = 5
         self._logger = logger
 
@@ -34,39 +33,30 @@ class RPCObject:
         self.add_attributes(attributes)
 
     def add_attributes(self, attributes):
-        self._logger.log(
-            self._logger.ULTRA, "RPCObject instancied with the following attributes : {}".format(attributes)
-        )
+        self._logger.log(self._logger.ULTRA,'RPCObject instancied with the following attributes : {}'.format(attributes))
         for key, value in attributes.items():
             key = key.lower()
-            if key in (
-                "wkui1_logon_domain",
-                "wkui1_logon_server",
-                "wkui1_oth_domains",
-                "wkui1_username",
-                "sesi10_cname",
-                "sesi10_username",
-            ):
-                value = value.rstrip("\x00")
+            if key in ('wkui1_logon_domain', 'wkui1_logon_server',
+                       'wkui1_oth_domains', 'wkui1_username',
+                       'sesi10_cname', 'sesi10_username'):
+                value = value.rstrip('\x00')
 
             setattr(self, key.lower(), value)
 
     def __str__(self):
         s = str()
-        members = inspect.getmembers(self, lambda x: not (inspect.isroutine(x)))
+        members = inspect.getmembers(self, lambda x: not(inspect.isroutine(x)))
         max_length = 0
-        # TODO: we redefine here because of a bug when used with invoke-processhunter
+        #TODO: we redefine here because of a bug when used with invoke-processhunter
         self._logger.ULTRA = 5
         for member in members:
-            if not member[0].startswith("_"):
+            if not member[0].startswith('_'):
                 if len(member[0]) > max_length:
                     max_length = len(member[0])
         for member in members:
-            self._logger.log(
-                self._logger.ULTRA, "Trying to print : attribute name = {0} / value = {1}".format(member[0], member[1])
-            )
-            if not member[0].startswith("_"):
-                s += "{}: {}{}\n".format(member[0], " " * (max_length - len(member[0])), member[1])
+            self._logger.log(self._logger.ULTRA,'Trying to print : attribute name = {0} / value = {1}'.format(member[0], member[1]))
+            if not member[0].startswith('_'):
+                s += '{}: {}{}\n'.format(member[0], ' ' * (max_length - len(member[0])), member[1])
 
         s = s[:-1]
         return s
@@ -75,39 +65,32 @@ class RPCObject:
         return str(self)
 
     def to_json(self):
-        members = inspect.getmembers(self, lambda x: not (inspect.isroutine(x)))
+        members = inspect.getmembers(self, lambda x: not(inspect.isroutine(x)))
         results = dict()
         for member in members:
-            if not member[0].startswith("_"):
-                results[member[0]] = member[1]
-        return results
-
+            if not member[0].startswith('_'):
+                results[member[0]]=member[1]
+        return(results)
 
 class TargetUser(RPCObject):
     pass
 
-
 class Session(RPCObject):
     pass
-
 
 class Share(RPCObject):
     pass
 
-
 class WkstaUser(RPCObject):
     pass
 
-
 class Group(RPCObject):
     pass
-
 
 class Disk(RPCObject):
     def __init__(self, obj):
         RPCObject.__init__(self, obj)
         self.disk = self.disk.rstrip("\x00")
-
 
 class Process(RPCObject):
     def __init__(self, obj):
@@ -115,6 +98,6 @@ class Process(RPCObject):
         self.user = str(self.user)
         self.domain = str(self.domain)
 
-
 class Event(RPCObject):
     pass
+

--- a/pywerview/objects/rpcobjects.py
+++ b/pywerview/objects/rpcobjects.py
@@ -18,9 +18,10 @@
 import logging
 import inspect
 
+
 class RPCObject:
     def __init__(self, obj):
-        logger = logging.getLogger('pywerview_main_logger.RPCObject')
+        logger = logging.getLogger("pywerview_main_logger.RPCObject")
         logger.ULTRA = 5
         self._logger = logger
 
@@ -33,30 +34,39 @@ class RPCObject:
         self.add_attributes(attributes)
 
     def add_attributes(self, attributes):
-        self._logger.log(self._logger.ULTRA,'RPCObject instancied with the following attributes : {}'.format(attributes))
+        self._logger.log(
+            self._logger.ULTRA, "RPCObject instancied with the following attributes : {}".format(attributes)
+        )
         for key, value in attributes.items():
             key = key.lower()
-            if key in ('wkui1_logon_domain', 'wkui1_logon_server',
-                       'wkui1_oth_domains', 'wkui1_username',
-                       'sesi10_cname', 'sesi10_username'):
-                value = value.rstrip('\x00')
+            if key in (
+                "wkui1_logon_domain",
+                "wkui1_logon_server",
+                "wkui1_oth_domains",
+                "wkui1_username",
+                "sesi10_cname",
+                "sesi10_username",
+            ):
+                value = value.rstrip("\x00")
 
             setattr(self, key.lower(), value)
 
     def __str__(self):
         s = str()
-        members = inspect.getmembers(self, lambda x: not(inspect.isroutine(x)))
+        members = inspect.getmembers(self, lambda x: not (inspect.isroutine(x)))
         max_length = 0
-        #TODO: we redefine here because of a bug when used with invoke-processhunter
+        # TODO: we redefine here because of a bug when used with invoke-processhunter
         self._logger.ULTRA = 5
         for member in members:
-            if not member[0].startswith('_'):
+            if not member[0].startswith("_"):
                 if len(member[0]) > max_length:
                     max_length = len(member[0])
         for member in members:
-            self._logger.log(self._logger.ULTRA,'Trying to print : attribute name = {0} / value = {1}'.format(member[0], member[1]))
-            if not member[0].startswith('_'):
-                s += '{}: {}{}\n'.format(member[0], ' ' * (max_length - len(member[0])), member[1])
+            self._logger.log(
+                self._logger.ULTRA, "Trying to print : attribute name = {0} / value = {1}".format(member[0], member[1])
+            )
+            if not member[0].startswith("_"):
+                s += "{}: {}{}\n".format(member[0], " " * (max_length - len(member[0])), member[1])
 
         s = s[:-1]
         return s
@@ -65,30 +75,39 @@ class RPCObject:
         return str(self)
 
     def to_json(self):
-        members = inspect.getmembers(self, lambda x: not(inspect.isroutine(x)))
+        members = inspect.getmembers(self, lambda x: not (inspect.isroutine(x)))
         results = dict()
         for member in members:
-            if not member[0].startswith('_'):
-                results[member[0]]=member[1]
-        return(results)
+            if not member[0].startswith("_"):
+                results[member[0]] = member[1]
+        return results
+
 
 class TargetUser(RPCObject):
     pass
 
+
 class Session(RPCObject):
     pass
+
 
 class Share(RPCObject):
     pass
 
+
 class WkstaUser(RPCObject):
     pass
+
 
 class Group(RPCObject):
     pass
 
+
 class Disk(RPCObject):
-    pass
+    def __init__(self, obj):
+        RPCObject.__init__(self, obj)
+        self.disk = self.disk.rstrip("\x00")
+
 
 class Process(RPCObject):
     def __init__(self, obj):
@@ -96,6 +115,6 @@ class Process(RPCObject):
         self.user = str(self.user)
         self.domain = str(self.domain)
 
+
 class Event(RPCObject):
     pass
-


### PR DESCRIPTION
Hey,
I was playing with NetExec and i figured out that disks contained trailing \x00 at the end of their name as shown in the screenshot. As this is the only place where \x00 is present, i think that might be unexpected.

![image](https://github.com/the-useless-one/pywerview/assets/49342114/2d60652d-904b-4627-84fd-86b7fb03dc05)

The PR simply consists of adding .rstrip("\x00") when a new disk has been found 