### PR TITLE
Fix wrong argument bug and add capibility to only supply nt hash

### DIFF
--- a/pywerview/requester.py
+++ b/pywerview/requester.py
@@ -174,7 +174,7 @@ class LDAPRequester():
                     self._logger.debug('Server requires Channel Binding Token but you are using password authentication,'
                                        ' falling back to SIMPLE authentication, hoping LDAPS port is open')
                     ldap_server_kwargs = {'host': self._domain_controller, 'formatter': self._formatter,
-                                          'get_info': ldap3.ALL, 'use_tls': True}
+                                          'get_info': ldap3.ALL, 'use_ssl': True}
                     server = ldap3.Server(**ldap_server_kwargs)
                     self._do_simple_auth(server)
                     return
@@ -189,7 +189,7 @@ class LDAPRequester():
                 self._logger.warning('Sealing not available, falling back to LDAPS')
                 # I don't know how to reuse the same Server object, but TLS enabled
                 ldap_server_kwargs = {'host': self._domain_controller, 'formatter': self._formatter,
-                                      'get_info': ldap3.ALL, 'use_tls': True}
+                                      'get_info': ldap3.ALL, 'use_ssl': True}
                 server = ldap3.Server(**ldap_server_kwargs)
                 self._do_ntlm_auth(server)
                 return
@@ -274,7 +274,7 @@ class LDAPRequester():
                 server.use_ssl = True
                 # I don't know how to reuse the same Server object, but switched to TLS
                 ldap_server_kwargs = {'host': self._domain_controller, 'formatter': self._formatter,
-                                      'get_info': ldap3.ALL, 'use_tls': True}
+                                      'get_info': ldap3.ALL, 'use_ssl': True}
                 server = ldap3.Server(**ldap_server_kwargs)
                 self._do_kerberos_auth(server)
                 return

--- a/pywerview/requester.py
+++ b/pywerview/requester.py
@@ -134,7 +134,9 @@ class LDAPRequester():
         ldap_connection_kwargs = {'server': server, 'user': '{}\\{}'.format(self._domain, self._user),
                                   'raise_exceptions': True, 'authentication': ldap3.NTLM}
 
-        if self._lmhash and self._nthash:
+        if self._lmhash or self._nthash:
+            if not self._lmhash: self._lmhash = 'aad3b435b51404eeaad3b435b51404ee'
+            if not self._nthash: self._nthash = '31d6cfe0d16ae931b73c59d7e0c089c0'
             ldap_connection_kwargs['password'] = '{}:{}'.format(self._lmhash, self._nthash)
         else:
             ldap_connection_kwargs['password'] = self._password


### PR DESCRIPTION
Two issues are addressed with this PR:

### Exception raised when using LDAP with TLS
 When establishing connections with LDAPS (e.g. ldapserverintegrity is set to 2) pywerview crashes due to `use_tls` being supplied to the `ldap3.Server()` instead of the expected `use_ssl` attribute.
![image](https://github.com/user-attachments/assets/1939720c-9494-48d5-ac20-0e9019a90be1)

### Supplying only NT or LM hashes
So far the implementation in pywerview requires to supply both the LM as well as the NT hash, likely because ldap3 requires the classic format `lm:nt`. As NetExec most often only knows the NT hash when doing pth, functions like `--groups` do not work, see [NetExec issue #562](https://github.com/Pennyw0rth/NetExec/issues/562). My suggestion would be to allow to only supply one of the hashes and replacing the other with an empty hash. This would solve the problem without the need to supply potentially "wrong" hashes from the NetExec side.

Before&After:
![image](https://github.com/user-attachments/assets/0611e7f0-d55d-485a-9d27-e9cd7e165051)
